### PR TITLE
Fix TypeError in Schoenfeld test for lifelines 0.30.0

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -1630,7 +1630,7 @@ class CoxModelingApp(ttk.Frame):
                 if hasattr(cph_main_rm, 'params_') and not cph_main_rm.params_.empty:
                     try:
                         self.log(f"DEBUG: Calling check_assumptions with df_for_fit_main shape: {df_for_fit_main.shape}", "DEBUG")
-                        results_check_assumptions = cph_main_rm.check_assumptions(df_for_fit_main, time_transform='log')
+                        results_check_assumptions = cph_main_rm.check_assumptions(df_for_fit_main)
 
                         if isinstance(results_check_assumptions, list) and len(results_check_assumptions) >= 2:
                             schoenfeld_df = results_check_assumptions[1]


### PR DESCRIPTION
This commit resolves a `TypeError` that prevented the Schoenfeld test (and proportional hazard assumption checking) from running correctly with lifelines version 0.30.0.

The error `ProportionalHazardMixin.check_assumptions() got an unexpected keyword argument 'time_transform'` occurred because the `time_transform` parameter is no longer supported in the `check_assumptions` method of `CoxPHFitter` in recent lifelines versions.

The `time_transform='log'` argument has been removed from the call to `cph_main_rm.check_assumptions(df_for_fit_main)` within the `_run_model_and_get_metrics` method in `MATLAB_cox.py`. The method will now use the default time handling provided by `lifelines 0.30.0`.

This change should allow the Schoenfeld test results to be calculated and displayed, and the corresponding plots to be generated, assuming the model itself fits correctly and has covariates.