### PR TITLE
Refactor: Migrate sample size calculator to use statsmodels

### DIFF
--- a/MATLAB_main_app.py
+++ b/MATLAB_main_app.py
@@ -13,18 +13,18 @@ if current_dir not in sys.path:
 
 # Importar las pestañas existentes y las nuevas
 try:
-    from MATLAB_data_filter import DataFilterTab # Ya no se usará directamente aquí para "Descriptivas"
+    from MATLAB_data_filter import DataFilterTab
     from MATLAB_regresiones import RegresionesTab
     from matlab_survival_analysis import SurvivalAnalysisTab
-    from matlab_tablasCat import TablasCat    # Tablas por Categoría
-    from MATLAB_graficaqq import GraficaQQ      # Gráfico Q-Q, medias, etc.
-    from MATLAB_map import MapTab               # Mapa de México
-    from MATLAB_cox import CoxModelingApp       # Modelado de Cox (nueva versión)
-    from MATLAB_mixmodel import MixModelTab       # Modelado Mixto (nueva versión adaptada a tkinter)
-    from MATLAB_princomp import PrincompTab # Nueva pestaña para PCA
-    from MATLAB_logistic_regression import LogisticRegressionTab # Pestaña para Regresión Logística
-    from MATLAB_general_charts import GeneralChartsApp # NUEVA PESTAÑA DE GRÁFICAS
-    from MATLAB_combined_analysis import CombinedAnalysisTab # NUEVA PESTAÑA COMBINADA
+    from matlab_tablasCat import TablasCat
+    from MATLAB_graficaqq import GraficaQQ
+    from MATLAB_map import MapTab
+    from MATLAB_cox import CoxModelingApp
+    from MATLAB_mixmodel import MixModelTab
+    from MATLAB_princomp import PrincompTab
+    from MATLAB_logistic_regression import LogisticRegressionTab
+    from MATLAB_general_charts import GeneralChartsApp
+    from MATLAB_combined_analysis import CombinedAnalysisTab
     from MATLAB_sample_size_calculator import SampleSizeCalculatorTab
 except ImportError as e:
     print("Error al importar uno o más módulos:", e)
@@ -33,67 +33,57 @@ except ImportError as e:
 class MainApp(tk.Tk):
     def __init__(self):
         super().__init__()
-        self.title("Proyecto FEP v2.01.02") # Actualización de versión menor por cambio estructural
+        self.title("Proyecto FEP v2.01.02")
         self.geometry("1200x800")
 
         style = ttk.Style(self)
         available_themes = style.theme_names()
         if 'clam' in available_themes:
             style.theme_use('clam')
-        
+
         self.notebook = ttk.Notebook(self)
         self.notebook.pack(fill="both", expand=True, padx=10, pady=10)
 
-        # Pestaña "Gráficas" (anteriormente "Descriptivas")
-        # Ahora usará GeneralChartsApp en lugar de DataFilterTab
-        self.charts_tab = GeneralChartsApp(self.notebook, main_app_instance=self) # Pasar self como main_app_instance
+        self.charts_tab = GeneralChartsApp(self.notebook, main_app_instance=self)
         self.notebook.add(self.charts_tab, text="Gráficas")
 
-        # Nueva Pestaña Combinada de Análisis y Gráficos
         self.combined_analysis_tab = CombinedAnalysisTab(self.notebook, main_app_instance=self)
         self.notebook.add(self.combined_analysis_tab, text="Análisis y Gráficos")
 
-        # Pestaña : Filtro de Datos (anteriormente "Descriptivas")
         self.data_filter_tab = DataFilterTab(self.notebook)
         self.notebook.add(self.data_filter_tab, text="Filtro de Datos")
 
-        # Pestaña : Regresiones y Dispersiones
         self.regresiones_tab = RegresionesTab(self.notebook)
         self.notebook.add(self.regresiones_tab, text="Regresiones")
 
-        # Pestaña : Análisis de supervivencia
         self.survival_tab = SurvivalAnalysisTab(self.notebook)
         self.notebook.add(self.survival_tab, text="Supervivencia")
 
-        # Pestaña : Tablas por Categoría
         self.tablas_cat_tab = TablasCat(self.notebook)
         self.notebook.add(self.tablas_cat_tab, text="Tablas")
 
-        # Pestaña : Gráficos Q-Q y otros análisis
         self.grafica_qq_tab = GraficaQQ(self.notebook)
         self.notebook.add(self.grafica_qq_tab, text="QQ")
 
-        # Pestaña : Mapa de México
         self.map_tab = MapTab(self.notebook)
         self.notebook.add(self.map_tab, text="Mapa")
 
-        # Pestaña : Modelado de Cox
         self.cox_tab = CoxModelingApp(self.notebook)
         self.notebook.add(self.cox_tab, text="Cox")
 
-        # Pestaña : Modelado Mixto
         self.mix_model_tab = MixModelTab(self.notebook)
         self.notebook.add(self.mix_model_tab, text="Mixtos")
 
-        # Pestaña : Principales Componentes
         self.princomp_tab = PrincompTab(self.notebook)
         self.notebook.add(self.princomp_tab, text="PCA")
 
-        # Pestaña : Regresión Logística
         self.logistic_tab = LogisticRegressionTab(self.notebook)
         self.notebook.add(self.logistic_tab, text="Logística")
 
-        # Pestaña : About
+        # Pestaña : Calculo de Muestra
+        self.sample_size_calculator_tab = SampleSizeCalculatorTab(self.notebook, main_app_instance=self)
+        self.notebook.add(self.sample_size_calculator_tab, text="Cálculo de Muestra")
+
         self.about_tab = ttk.Frame(self.notebook)
         self.notebook.add(self.about_tab, text="About")
         about_label = ttk.Label(self.about_tab, text="Desarrollado por: César Misael Cerecedo Zapata\nVersión: 2.01.02", justify=tk.LEFT, padding=(10, 10))

--- a/requirements_matabs.txt
+++ b/requirements_matabs.txt
@@ -14,4 +14,3 @@ scipy
 seaborn
 statsmodels
 plotly
-sample-size


### PR DESCRIPTION
This commit refactors the SampleSizeCalculatorTab to use the `statsmodels` library for power and precision-based sample size calculations, replacing the previous `sample-size` library.

Key changes:
- Replaced `sample_size.ProportionMetric` and `sample_size.MeanMetric` with appropriate functions from `statsmodels.stats.power` (TTestIndPower, NormalIndPower) and `statsmodels.stats.proportion` (effectsize_proportions, samplesize_confint_proportion).
- Calculations for power analysis (comparing two proportions or two means) now use `statsmodels`.
- Calculation for precision of a proportion now uses `statsmodels`.
- Calculation for precision of a mean continues to use `scipy.stats.norm` with the standard formula.
- Updated `requirements_matabs.txt` to include `statsmodels` and remove `sample-size`.
- Ensured critical imports are checked and handled.
- Removed a redundant local import of `scipy.stats.norm`.

This change aims to improve compatibility and leverage a more standard statistical library within the Python ecosystem.