### PR TITLE
Fix: Use 'training_dataframe' kwarg for compute_residuals

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -2364,7 +2364,7 @@ class CoxModelingApp(ttk.Frame):
             # compute_residuals should ideally use the same data context as fit.
             # The previous version explicitly passed training_df=df_for_schoenfeld.
             # The subtask asks to remove it, relying on the fitter's internal state.
-            scaled_residuals = cph_sch.compute_residuals(kind='schoenfeld_scaled')
+            scaled_residuals = cph_sch.compute_residuals(training_dataframe=df_for_schoenfeld, kind='schoenfeld_scaled')
 
             if scaled_residuals.empty:
                 self.log(f"Residuos de Schoenfeld escalados vacíos para '{name_sch}'.", "WARN")


### PR DESCRIPTION
- I corrected the call to `compute_residuals` in the `show_schoenfeld` method in `MATLAB_cox.py`.
- I changed from `kind='schoenfeld_scaled'` (no df argument) to `training_dataframe=df_for_schoenfeld, kind='schoenfeld_scaled'`.
- This addresses the `TypeError: RegressionFitter.compute_residuals() missing 1 required positional argument: 'training_dataframe'` by providing the dataframe using the correct keyword argument name for your lifelines version.