### PR TITLE
Fix: Correct 'kind' argument for Schoenfeld residuals

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -2364,7 +2364,7 @@ class CoxModelingApp(ttk.Frame):
             # compute_residuals should ideally use the same data context as fit.
             # The previous version explicitly passed training_df=df_for_schoenfeld.
             # The subtask asks to remove it, relying on the fitter's internal state.
-            scaled_residuals = cph_sch.compute_residuals(training_dataframe=df_for_schoenfeld, kind='schoenfeld_scaled')
+            scaled_residuals = cph_sch.compute_residuals(training_dataframe=df_for_schoenfeld, kind='scaled_schoenfeld')
 
             if scaled_residuals.empty:
                 self.log(f"Residuos de Schoenfeld escalados vacíos para '{name_sch}'.", "WARN")


### PR DESCRIPTION
- In `MATLAB_cox.py`, within the `show_schoenfeld` method, I changed the `kind` argument in the `compute_residuals` call from `'schoenfeld_scaled'` to `'scaled_schoenfeld'`.
- This fixes an `AssertionError` caused by an incorrect keyword for the type of residual to compute.