### PR TITLE
Fix: Correct UnboundLocalError for df_final_fit_shape

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -1884,7 +1884,6 @@ class CoxModelingApp(ttk.Frame):
             "y_survival_used_for_fit": y_survival_rm.copy(),
             "penalizer_value": penalizer_val_rm, "l1_ratio_value": l1_ratio_val_rm,
             "tie_method_used": ui_selected_tie_method,
-            "df_final_fit_shape": df_for_fit_main.shape,
             "metrics": {}, "schoenfeld_results": None, "model": None, "loglik_null": None,
             "c_index_cv_mean": None, "c_index_cv_std": None,
             "schoenfeld_status_message": None, # Initialize status message
@@ -1905,6 +1904,7 @@ class CoxModelingApp(ttk.Frame):
             # Siempre usar el DataFrame original (df_lifelines_rm) y la fórmula de Patsy (formula_patsy_rm)
             # lifelines.fit() se encargará de construir la matriz de diseño internamente.
             df_for_fit_main = df_lifelines_rm.copy()
+            model_data_rm["df_final_fit_shape"] = df_for_fit_main.shape
             actual_formula_for_fit = formula_patsy_rm
             
             self.log(f"DEBUG: df_for_fit_main columns before fit: {df_for_fit_main.columns.tolist()}", "DEBUG")


### PR DESCRIPTION
This commit addresses an UnboundLocalError that occurred because `df_for_fit_main.shape` was accessed before `df_for_fit_main` was assigned a value within the `_run_model_and_get_metrics` function.

The previous commit (fix-cox-report-observations) introduced the `df_final_fit_shape` key but placed its assignment incorrectly within the `model_data_rm` dictionary initialization.

This commit:
1. Removes `"df_final_fit_shape": df_for_fit_main.shape,` from the initial dictionary declaration in `_run_model_and_get_metrics`.
2. Adds `model_data_rm["df_final_fit_shape"] = df_for_fit_main.shape` on a new line *after* `df_for_fit_main` is defined (specifically, after `df_for_fit_main = df_lifelines_rm.copy()`) and after the `model_data_rm` dictionary has been initialized.

This ensures that `df_for_fit_main` exists when its shape is accessed, resolving the error and allowing the methodological report to correctly display the number of observations.