### PR TITLE
Fix: Resolve UnboundLocalError for traceback module

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -2111,7 +2111,6 @@ class CoxModelingApp(ttk.Frame):
             elif self.calculate_cv_cindex_var.get(): self.log("C-Index CV no calculado (modelo nulo o sin X_design).", "INFO")
 
         except Exception as e_fit_main:
-            import traceback # Explicitly import traceback here
             self.log(f"Error ajuste modelo/métricas '{model_name_rm}': {e_fit_main}", "ERROR"); traceback.print_exc(limit=5); return None
 
         model_data_rm["_df_for_fit_main_INTERNAL_USE"] = df_lifelines_rm.copy()


### PR DESCRIPTION
An UnboundLocalError for the `traceback` module was occurring in the `_run_model_and_get_metrics` function, specifically when handling exceptions during C-Index cross-validation.

The error was caused by an `import traceback` statement located inside an `except Exception as e_fit_main:` block. This local import caused Python to treat `traceback` as a local variable for the entire `_run_model_and_get_metrics` function scope. If an exception occurred in an earlier `except` block (like the one for C-Index CV) that also called `traceback.print_exc()`, the local `traceback` variable would not have been assigned yet, leading to the UnboundLocalError.

This commit resolves the issue by:
1. Removing the `import traceback` line from the `except Exception as e_fit_main:` block in `_run_model_and_get_metrics`.

The globally imported `traceback` module (confirmed to be present at the top of the file) will now be used consistently throughout the function, preventing the error.