### PR TITLE
Fix: Correct variable expansion for file checks in MATHABS.bat

### DIFF
--- a/MATHABS.bat
+++ b/MATHABS.bat
@@ -29,13 +29,13 @@ if errorlevel 1 (
 echo Python encontrado.
 REM --- VERIFICAR ARCHIVOS NECESARIOS EN EL DIRECTORIO DEL SCRIPT ---
 echo Buscando archivos de la aplicacion en: "%APP_ROOT_DIR%"
-if not exist "%APP_ROOT_DIR%\%%REQUIREMENTS_FILE_NAME%%" (
-    echo ERROR: Archivo de requerimientos "%%REQUIREMENTS_FILE_NAME%%" no encontrado en "%APP_ROOT_DIR%".
+if not exist "%APP_ROOT_DIR%\%REQUIREMENTS_FILE_NAME%" (
+    echo ERROR: Archivo de requerimientos "%REQUIREMENTS_FILE_NAME%" no encontrado en "%APP_ROOT_DIR%".
     pause
     %e_cmd% /b 1
 )
-if not exist "%APP_ROOT_DIR%\%%MAIN_APP_FILE_NAME%%" (
-    echo ERROR: Archivo principal de la aplicacion "%%MAIN_APP_FILE_NAME%%" no encontrado en "%APP_ROOT_DIR%".
+if not exist "%APP_ROOT_DIR%\%MAIN_APP_FILE_NAME%" (
+    echo ERROR: Archivo principal de la aplicacion "%MAIN_APP_FILE_NAME%" no encontrado en "%APP_ROOT_DIR%".
     pause
     %e_cmd% /b 1
 )


### PR DESCRIPTION
Previously, the script used `%%VAR_NAME%%` when checking for the existence of the requirements and main application files. This has been corrected to use `%VAR_NAME%` for proper variable expansion in the `IF NOT EXIST` commands and associated `ECHO` statements.

This resolves an issue where the script would fail to find these files due to incorrect variable dereferencing.

The specific changes are:
- `%%REQUIREMENTS_FILE_NAME%%` changed to `%REQUIREMENTS_FILE_NAME%`
- `%%MAIN_APP_FILE_NAME%%` changed to `%MAIN_APP_FILE_NAME%` in the relevant `IF NOT EXIST` and `ECHO` lines within the file verification section.