### PR TITLE
Fix: Resolve AttributeError for generate_calibration_plot

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -2636,7 +2636,8 @@ class CoxModelingApp(ttk.Frame):
                 messagebox.showinfo("Resultados Predicción", "Curva de predicción completa generada.", parent=dialog_pred_ref)
         except Exception as e_curve_pred: self.log(f"Error pred/plot: {e_curve_pred}","ERROR"); traceback.print_exc(limit=3); messagebox.showerror("Error Pred/Plot",f"Error al predecir/plotear:\n{e_curve_pred}",parent=dialog_pred_ref)
 
-
+    def generate_calibration_plot(self): # Ensure this line has correct class-level indentation
+        if not self._check_model_selected_and_valid(): return
 
         # self.log("DEBUG: generate_calibration_plot called", "DEBUG") # Optional: for debugging entry
 


### PR DESCRIPTION
An AttributeError was occurring because the `generate_calibration_plot` method was not correctly defined as part of the `CoxModelingApp` class. The `def generate_calibration_plot(self):` line was missing, causing the Python interpreter to not recognize it as a method, leading to the error when `self.generate_calibration_plot` was accessed.

This commit fixes the issue by:
1. Reinstating the `def generate_calibration_plot(self):` line at the correct indentation level within the `CoxModelingApp` class in `MATLAB_cox.py`.
2. Ensuring all the previously developed logic for this method (including K-Fold cross-validation and custom plotting) is correctly encapsulated within this method definition.

This change should allow the application to start and the "Gráf. Calibración" button to correctly reference its target method.