### PR TITLE
Fix: Improve robustness of custom calibration plot to fold failures

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -2720,11 +2720,19 @@ class CoxModelingApp(ttk.Frame):
 
             if df_train.empty or df_test.empty:
                 self.log(f"Fold {fold_count} skipped: df_train o df_test vacío.", "WARN")
+                x_coords_actual_h.append(np.nan)
+                y_coords_predicted_h.append(np.nan)
+                x_low_ci_h_fold.append(np.nan)
+                x_high_ci_h_fold.append(np.nan)
                 continue
 
             # Ensure there are events in the training set for model fitting
             if df_train[event_col].sum() == 0:
                 self.log(f"Fold {fold_count} skipped: No events in training data for this fold.", "WARN")
+                x_coords_actual_h.append(np.nan)
+                y_coords_predicted_h.append(np.nan)
+                x_low_ci_h_fold.append(np.nan)
+                x_high_ci_h_fold.append(np.nan)
                 continue
 
             # 1. Refit Cox Model on Training Data
@@ -2733,6 +2741,10 @@ class CoxModelingApp(ttk.Frame):
                 cph_fold.fit(df_train, duration_col=time_col, event_col=event_col, formula=formula_patsy)
             except Exception as e_fold_fit:
                 self.log(f"Error ajustando modelo en Fold {fold_count}: {e_fold_fit}", "WARN")
+                x_coords_actual_h.append(np.nan)
+                y_coords_predicted_h.append(np.nan)
+                x_low_ci_h_fold.append(np.nan)
+                x_high_ci_h_fold.append(np.nan)
                 continue
 
             # 2. Calculate Y-coordinate (Mean Predicted Hazard for Test Fold)
@@ -2858,7 +2870,7 @@ class CoxModelingApp(ttk.Frame):
                 lower_errors[i] = 0 # Or some other indicator that it's missing
 
             if pd.notna(x_err_high_valid[i]) and pd.notna(x_plot[i]):
-                upper_errors[i] = x_err_high_valid[i] - x_plot
+                upper_errors[i] = x_err_high_valid[i] - x_plot[i]
             else:
                 upper_errors[i] = 0 # Or some other indicator
 


### PR DESCRIPTION
This commit addresses a ValueError in `generate_calibration_plot` that occurred when a `ConvergenceError` happened during the K-fold cross-validation loop.

The main issues were:
1. Inconsistent list lengths for coordinates and confidence intervals if a fold's model fitting failed, as `np.nan` was not consistently appended to all relevant lists before continuing.
2. A minor indexing error in the calculation of upper error bar lengths.

This commit implements the following fixes in `generate_calibration_plot`:
- Ensures that if `cph_fold.fit()` fails for a fold (or if a fold is skipped due to empty data or no events), `np.nan` is explicitly appended to all four lists: `x_coords_actual_h`, `y_coords_predicted_h`, `x_low_ci_h_fold`, and `x_high_ci_h_fold`. This maintains synchronized list lengths of 10 (for 10 folds).
- Corrects the upper error bar calculation from `upper_errors[i] = x_err_high_valid[i] - x_plot` to `upper_errors[i] = x_err_high_valid[i] - x_plot[i]`.
- Verifies that the existing NaN filtering logic (using `valid_indices`) correctly processes these potentially NaN-padded lists before plotting, ensuring that error calculations and plotting commands operate on consistent data.

These changes make the calibration plot generation more robust when individual folds encounter convergence or data issues.