### PR TITLE
Fix: Correct IndentationError in MATLAB_cox.py

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -2891,3 +2891,4 @@ class CoxModelingApp(ttk.Frame):
             return # No fig_cal to close yet
 
     def show_variable_impact_plot(self):
+        pass


### PR DESCRIPTION
The function `show_variable_impact_plot` was missing an indented block after its definition, likely due to a previous merge conflict marker removal.

This commit adds a `pass` statement to the function body to resolve the IndentationError and ensure the program can run.