### PR TITLE
Fix: Correct AttributeError in MATLAB_cox.py

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -931,7 +931,7 @@ class CoxModelingApp(ttk.Frame):
 
         # Botón para configuración detallada
         btn_config_detallada = ttk.Button(frame_lista_covariables, text="Configurar Seleccionadas Detalladamente...",
-                                          command=self.open_detailed_configuration_dialog)
+                                          command=self.open_detailed_covariate_config_dialog)
         btn_config_detallada.pack(pady=5, padx=5, fill=tk.X)
 
 


### PR DESCRIPTION
The `btn_config_detallada` button in the `create_preproc_controls` method was attempting to call a non-existent method `self.open_detailed_configuration_dialog`.

This commit corrects the method call to
`self.open_detailed_covariate_config_dialog`, which is the correctly defined method name in the CoxModelingApp class.