### PR TITLE
I fixed an AttributeError and addressed module import issues.

### DIFF
--- a/MATLAB_cox.py
+++ b/MATLAB_cox.py
@@ -841,6 +841,19 @@ class CoxModelingApp(ttk.Frame):
 
         self.log("Interfaz de CoxModelingApp inicializada y controles creados.", "INFO")
 
+    def open_detailed_covariate_config_dialog(self):
+        sel_indices = self.listbox_covariables_disponibles.curselection()
+        selected_covs = [self.listbox_covariables_disponibles.get(i) for i in sel_indices]
+
+        if not selected_covs:
+            messagebox.showwarning("Ninguna covariable seleccionada",
+                                   "Por favor, seleccione una o más covariables de la lista para configurar detalladamente.",
+                                   parent=self.parent_for_dialogs)
+            return
+
+        # Assuming DetailedCovariateConfigDialog is defined elsewhere and handles its own logic
+        DetailedCovariateConfigDialog(self.parent_for_dialogs, self, selected_covs)
+
     def log(self, message_text, level_str="INFO"):
         if not hasattr(self, 'log_text_widget'):
             print(f"FALLBACK LOG: [{level_str.upper()}] {message_text}")

--- a/requirements_matabs.txt
+++ b/requirements_matabs.txt
@@ -1,3 +1,8 @@
+# Python Version Recommendation:
+# This project is best run with Python 3.9 or 3.10.
+# Using Python 3.11+ may lead to import errors with some dependencies (e.g., 'inspect.formatargspec').
+# Ensure your environment uses one of the recommended Python versions.
+#
 bottleneck
 factor_analyzer
 flask
@@ -12,6 +17,8 @@ pyarrow
 scikit-learn
 scipy
 seaborn
-statsmodels
+# statsmodels pinned to 0.13.5 for compatibility with numpy<2.0 and Python < 3.11.
+# Python < 3.11 (e.g., 3.9 or 3.10) is strongly recommended to avoid 'inspect.formatargspec' errors.
+statsmodels==0.13.5
 plotly
 squarify


### PR DESCRIPTION
- I defined `open_detailed_covariate_config_dialog` in `MATLAB_cox.py` to resolve an AttributeError.
- I pinned `statsmodels` to `0.13.5` in `requirements_matabs.txt` to mitigate `inspect.formatargspec` import errors when you are using Python < 3.11.
- I added comments to `requirements_matabs.txt` recommending Python 3.9 or 3.10 for optimal compatibility with project dependencies.
- I confirmed the existing `brier_score` import handling in `MATLAB_cox.py` is sufficient.